### PR TITLE
Add legalisation transactions

### DIFF
--- a/app/controllers/epdq_transactions_controller.rb
+++ b/app/controllers/epdq_transactions_controller.rb
@@ -15,6 +15,9 @@ class EpdqTransactionsController < ApplicationController
   rescue Transaction::InvalidDocumentType
     @errors = [:document_type]
     render :action => "start"
+  rescue Transaction::InvalidPostageOption
+    @errors = [:postage_option]
+    render :action => "start"
   end
 
   def done

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,13 +1,10 @@
 module ApplicationHelper
 
-  def pluralize_document_type_label(quantity, label)
-    return label if quantity == 1
-
-    case label
-    when /\Acertificate/i then label.sub(/\A([cC])ertificate/i, '\1ertificates')
-    when "Nulla osta" then "Nulla ostas" # pluralize thinks this is already plural
+  def format_money(value)
+    case value.to_s
+    when %r{\A[0-9]+\z} then value
     else
-      label.pluralize(quantity)
+      "%0.2f" % value
     end
   end
 end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -3,6 +3,7 @@ class Transaction < OpenStruct
 
   class TransactionNotFound < StandardError; end
   class InvalidDocumentType < StandardError; end
+  class InvalidPostageOption < StandardError; end
 
   def calculate_total(values)
     calculator = TransactionCalculator.new(self)

--- a/app/views/epdq_transactions/confirm.html.erb
+++ b/app/views/epdq_transactions/confirm.html.erb
@@ -11,7 +11,7 @@
   <div class="article-container group">
       <article role="article" class="group">
        <div class="inner">
-          <p>The cost for <%= @calculation.item_list %> is &pound;<%= "%0.2f" % @calculation.total_cost %>.</p>
+          <p>The cost for <%= @calculation.item_list %> is &pound;<%= format_money @calculation.total_cost %>.</p>
 
           <%= form_tag @epdq_request.request_url, :class => "epdq-submit" do %>
             <%- @epdq_request.form_attributes.each do |k, v| -%>

--- a/app/views/epdq_transactions/confirm.html.erb
+++ b/app/views/epdq_transactions/confirm.html.erb
@@ -11,7 +11,7 @@
   <div class="article-container group">
       <article role="article" class="group">
        <div class="inner">
-          <p>The cost for <%= @calculation.item_list %> is &pound;<%= @calculation.total_cost %>.</p>
+          <p>The cost for <%= @calculation.item_list %> is &pound;<%= "%0.2f" % @calculation.total_cost %>.</p>
 
           <%= form_tag @epdq_request.request_url, :class => "epdq-submit" do %>
             <%- @epdq_request.form_attributes.each do |k, v| -%>

--- a/app/views/epdq_transactions/start.html.erb
+++ b/app/views/epdq_transactions/start.html.erb
@@ -64,7 +64,7 @@
                 <% @transaction.postage_options.each do |value,option| %>
                 <li>
                   <%= label_tag "transaction_postage_option_#{value}" do %>
-                    <%= radio_button_tag "transaction[postage_option]", value %> <%= option['label'] %> - &pound;<%= option['cost'] %>
+                    <%= radio_button_tag "transaction[postage_option]", value %> <%= option['label'] %> - &pound;<%= "%0.2f" % option['cost'] %>
                   <% end %>
                 </li>
                 <% end %>

--- a/app/views/epdq_transactions/start.html.erb
+++ b/app/views/epdq_transactions/start.html.erb
@@ -55,12 +55,28 @@
               </p>
             <% end %>
 
-            <p>
-              <%= label_tag "transaction_postage" do %>
-                Do you require postage? This costs &pound;<%= @transaction.postage_cost %>.<br />
-                <%= select_tag "transaction[postage]", options_for_select([["Yes", "yes"], ["No", "no"]]), :id => "transaction_postage" %>
-              <% end %>
-            </p>
+            <% if @transaction.postage_options.present? %>
+              <p>
+                Which postage method do you require?
+              </p>
+
+              <ul>
+                <% @transaction.postage_options.each do |value,option| %>
+                <li>
+                  <%= label_tag "transaction_postage_option_#{value}" do %>
+                    <%= radio_button_tag "transaction[postage_option]", value %> <%= option['label'] %> - &pound;<%= option['cost'] %>
+                  <% end %>
+                </li>
+                <% end %>
+              </ul>
+            <% else %>
+              <p>
+                <%= label_tag "transaction_postage" do %>
+                  Do you require postage? This costs &pound;<%= @transaction.postage_cost %>.<br />
+                  <%= select_tag "transaction[postage]", options_for_select([["Yes", "yes"], ["No", "no"]]), :id => "transaction_postage" %>
+                <% end %>
+              </p>
+            <% end %>
 
             <p id="get-started" class="get-started group">
               <button class="button" type="submit" >Calculate total</button>

--- a/app/views/epdq_transactions/start.html.erb
+++ b/app/views/epdq_transactions/start.html.erb
@@ -35,21 +35,21 @@
             <% if @transaction.registration %>
               <p>
                 <%= label_tag "transaction_registration_count" do %>
-                  How many <%= @transaction.registration_type %> registrations do you need to register?<br />Each registration costs &pound;<%= @transaction.registration_cost %>.<br />
+                  How many <%= @transaction.registration_type %> registrations do you need to register?<br />Each registration costs &pound;<%= format_money @transaction.registration_cost %>.<br />
                   <%= select_tag "transaction[registration_count]", options_for_select(1..9), :id => "transaction_registration_count" %>
                 <% end %>
               </p>
 
               <p>
                 <%= label_tag "transaction_document_count" do %>
-                  How many <%= @transaction.registration_type %> certificates do you require?<br />Each certificate costs &pound;<%= @transaction.document_cost %>.<br />
+                  How many <%= @transaction.registration_type %> certificates do you require?<br />Each certificate costs &pound;<%= format_money @transaction.document_cost %>.<br />
                   <%= select_tag "transaction[document_count]", options_for_select(1..9), :id => "transaction_document_count" %>
                 <% end %>
               </p>
             <% else %>
               <p>
                 <%= label_tag "transaction_document_count" do %>
-                  How many documents do you require?<br />Each document costs &pound;<%= @transaction.document_cost %>.<br />
+                  How many documents do you require?<br />Each document costs &pound;<%= format_money @transaction.document_cost %>.<br />
                   <%= select_tag "transaction[document_count]", options_for_select(1..9), :id => "transaction_document_count" %>
                 <% end %>
               </p>
@@ -64,7 +64,7 @@
                 <% @transaction.postage_options.each do |value,option| %>
                 <li>
                   <%= label_tag "transaction_postage_option_#{value}" do %>
-                    <%= radio_button_tag "transaction[postage_option]", value %> <%= option['label'] %> - &pound;<%= "%0.2f" % option['cost'] %>
+                    <%= radio_button_tag "transaction[postage_option]", value %> <%= option['label'] %> - &pound;<%= format_money option['cost'] %>
                   <% end %>
                 </li>
                 <% end %>
@@ -72,7 +72,7 @@
             <% else %>
               <p>
                 <%= label_tag "transaction_postage" do %>
-                  Do you require postage? This costs &pound;<%= @transaction.postage_cost %>.<br />
+                  Do you require postage? This costs &pound;<%= format_money @transaction.postage_cost %>.<br />
                   <%= select_tag "transaction[postage]", options_for_select([["Yes", "yes"], ["No", "no"]]), :id => "transaction_postage" %>
                 <% end %>
               </p>

--- a/app/views/epdq_transactions/start.html.erb
+++ b/app/views/epdq_transactions/start.html.erb
@@ -69,7 +69,7 @@
                 </li>
                 <% end %>
               </ul>
-            <% else %>
+            <% elsif @transaction.postage_cost.present? %>
               <p>
                 <%= label_tag "transaction_postage" do %>
                   Do you require postage? This costs &pound;<%= format_money @transaction.postage_cost %>.<br />

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,3 +5,4 @@ en:
   epdq:
     errors:
       document_type: Please choose a document type
+      postage_option: Please choose a postage option

--- a/lib/transaction_calculator.rb
+++ b/lib/transaction_calculator.rb
@@ -11,28 +11,29 @@ class TransactionCalculator
     document_type = values[:document_type]
     postage_option = values[:postage_option]
 
-    item_list = []
-
+    item_list = Hash.new("")
     document_total = @transaction.document_cost * document_count
 
-    if @transaction.postage_options
-      postage_option = @transaction.postage_options[postage_option]
+    if @transaction.postage_options.present?
+      if postage_option.present?
+        postage_method = @transaction.postage_options[postage_option]
+      end
+      raise Transaction::InvalidPostageOption unless postage_method
 
-      raise Transaction::InvalidPostageOption unless postage_option
-
-      postage_total = postage_option['cost']
-    else
-      postage_total = postage ? @transaction.postage_cost : 0
+      postage_total = postage_method['cost']
+      item_list[:postage] = ", plus #{postage_method['label']} postage,"
+    elsif postage
+      postage_total = @transaction.postage_cost
+      item_list[:postage] = ", plus postage,"
     end
-
-    total_cost = document_total + postage_total
+    total_cost = document_total + (postage_total || 0)
 
     if @transaction.registration
       registration_count = values[:registration_count].to_i
       registration_total = @transaction.registration_cost * registration_count
       total_cost += registration_total
 
-      item_list << "#{registration_count} " + pluralize_document_type_label(registration_count, "#{@transaction.registration_type} registration") + " and "
+      item_list[:registration] = "#{registration_count} " + pluralize_document_type_label(registration_count, "#{@transaction.registration_type} registration") + " and "
       document_type_label = "#{@transaction.registration_type} certificate"
     end
 
@@ -42,16 +43,13 @@ class TransactionCalculator
       end
       raise Transaction::InvalidDocumentType unless document_type_label
     end
+    item_list[:document] = "#{document_count} " + pluralize_document_type_label(document_count, document_type_label || "document")
 
-    item_list << "#{document_count} " + pluralize_document_type_label(document_count, document_type_label || "document")
-
-    if postage_option
-      item_list << ", plus #{postage_option['label']} postage,"
-    elsif postage
-      item_list << ", plus postage,"
-    end
-
-    return OpenStruct.new(:total_cost => total_cost, :item_list => item_list.join(''))
+    item_list_order = [:registration, :document, :postage]
+    return OpenStruct.new(
+      :total_cost => total_cost,
+      :item_list => item_list_order.map {|key| item_list[key] }.join("")
+    )
   end
 
   private

--- a/lib/transactions.yml
+++ b/lib/transactions.yml
@@ -45,3 +45,7 @@ pay-to-get-documents-legalised-by-post:
     rest-of-world:
       label: "Rest of the World"
       cost: 25
+pay-for-documents-legalised-drop-off:
+  title: Pay to get documents legalised using the drop-off service
+  document_cost: 75
+  postage_cost: false

--- a/lib/transactions.yml
+++ b/lib/transactions.yml
@@ -26,3 +26,22 @@ pay-to-register-birth-abroad:
   registration: true
   registration_cost: 105
   registration_type: birth
+get-a-document-legalised-by-post:
+  title: Get a document legalised by post
+  document_cost: 30
+  postage_options:
+    courier-or-prepaid:
+      label: Courier or prepaid envelope
+      cost: 0
+    uk:
+      label: Delivery to the United Kingdom or British Forces Post Office
+      cost: 6
+    uk-with-insurance:
+      label: "Delivery to the United Kingdom or British Forces Post Office, with insurance"
+      cost: 12
+    europe:
+      label: "Europe (excluding Russia, Turkey, Bosnia, Croatia, Albania, Belarus, Macedonia, Moldova, Montenegro, Ukraine)"
+      cost: 14.50
+    rest-of-world:
+      label: "Rest of the World"
+      cost: 25

--- a/lib/transactions.yml
+++ b/lib/transactions.yml
@@ -26,8 +26,8 @@ pay-to-register-birth-abroad:
   registration: true
   registration_cost: 105
   registration_type: birth
-get-a-document-legalised-by-post:
-  title: Get a document legalised by post
+pay-to-get-documents-legalised-by-post:
+  title: Pay to get documents legalised by post
   document_cost: 30
   postage_options:
     courier-or-prepaid:

--- a/spec/lib/transaction_calculator_spec.rb
+++ b/spec/lib/transaction_calculator_spec.rb
@@ -114,4 +114,50 @@ describe TransactionCalculator do
     end
   end
 
+  describe "given a transaction with postage options" do
+    before do
+      @transaction = OpenStruct.new(
+        :document_cost => 20,
+        :postage_options => {
+          "horse-and-cart" => {
+            "label" => "Horse and cart",
+            "cost" => 10
+          },
+          "iron-horse" => {
+            "label" => "Iron horse",
+            "cost" => 20
+          },
+          "flying-machine" => {
+            "label" => "Flying machine",
+            "cost" => 35
+          }
+        })
+      @calculator = TransactionCalculator.new(@transaction)
+    end
+
+    it "calculates the cost of postage" do
+      @calculator.calculate(:postage_option => "iron-horse").total_cost.should == 20
+    end
+
+    it "calculates the cost of postage and documents" do
+      @calculator.calculate(:postage_option => "flying-machine", :document_count => 3).total_cost.should == 95
+    end
+
+    it "builds an item list including the postage type" do
+      @calculator.calculate(:postage_option => "horse-and-cart").item_list.should == "0 documents, plus Horse and cart postage,"
+    end
+
+    it "builds an item list of multiple documents including the postage type" do
+      @calculator.calculate(:postage_option => "flying-machine", :document_count => 3).item_list.should == "3 documents, plus Flying machine postage,"
+    end
+
+    it "raises an error if no postage option set" do
+      expect{ @calculator.calculate(:postage_option => nil) }.to raise_error(Transaction::InvalidPostageOption)
+    end
+
+    it "raises an error if postage option doesn't exist" do
+      expect{ @calculator.calculate(:postage_option => "mailman") }.to raise_error(Transaction::InvalidPostageOption)
+    end
+  end
+
 end

--- a/spec/lib/transaction_calculator_spec.rb
+++ b/spec/lib/transaction_calculator_spec.rb
@@ -160,4 +160,22 @@ describe TransactionCalculator do
     end
   end
 
+  describe "given a transaction without postage" do
+    before do
+      @transaction = OpenStruct.new(
+        :document_cost => 20,
+        :postage_cost => false
+      )
+      @calculator = TransactionCalculator.new(@transaction)
+    end
+
+    it "calculates the document cost" do
+      @calculator.calculate(:document_count => 3).total_cost.should == 60
+    end
+
+    it "builds an item list which does not include postage" do
+      @calculator.calculate(:document_count => 3).item_list.should == "3 documents"
+    end
+  end
+
 end


### PR DESCRIPTION
This branch contains the two legalisation transactions.

The postal legalisation transaction has a new field for selecting the postage type.

There's a few bits of tidying up on the calculator and money formatting too.
