### PR TITLE
Move the start page for a transaction

### DIFF
--- a/app/controllers/epdq_transactions_controller.rb
+++ b/app/controllers/epdq_transactions_controller.rb
@@ -6,6 +6,10 @@ class EpdqTransactionsController < ApplicationController
   def index
   end
 
+  def show
+    redirect_to transaction_path(@transaction.slug)
+  end
+
   def start
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 TransactionWrappers::Application.routes.draw do
-  get "/:slug" => "epdq_transactions#start", :as => :transaction
+  get "/:slug" => "epdq_transactions#show"
+  get "/:slug/start" => "epdq_transactions#start", :as => :transaction
   post "/:slug/confirm" => "epdq_transactions#confirm", :as => :transaction_confirm
   get "/:slug/done" => "epdq_transactions#done", :as => :transaction_done
 

--- a/spec/controllers/epdq_transactions_controller_spec.rb
+++ b/spec/controllers/epdq_transactions_controller_spec.rb
@@ -2,6 +2,23 @@ require 'spec_helper'
 
 describe EpdqTransactionsController do
 
+  describe "redirection to start page" do
+    it "returns 404 status if slug is empty" do
+      get :show, :slug => ""
+      response.should be_not_found
+    end
+
+    it "returns 404 status if slug is not found" do
+      get :show, :slug => "pay-for-all-the-things"
+      response.should be_not_found
+    end
+
+    it "redirects to the start page for a valid slug" do
+      get :show, :slug => "pay-foreign-marriage-certificates"
+      response.should redirect_to("/pay-foreign-marriage-certificates/start")
+    end
+  end
+
   describe "start pages" do
     it "returns 404 status if slug is empty" do
       get :start, :slug => ""

--- a/spec/features/epdq_transactions_spec.rb
+++ b/spec/features/epdq_transactions_spec.rb
@@ -4,8 +4,14 @@ require "spec_helper"
 feature "epdq transactions" do
 
   describe "paying for a certificate for marriage" do
-    it "renders the content and form" do
+    it "redirects to the start page" do
       visit "/pay-foreign-marriage-certificates"
+
+      current_path.should == "/pay-foreign-marriage-certificates/start"
+    end
+
+    it "renders the content and form" do
+      visit "/pay-foreign-marriage-certificates/start"
 
       within(:css, "header.page-header") do
         page.should have_content("Payment for certificates to get married abroad")
@@ -32,7 +38,7 @@ feature "epdq transactions" do
 
     context "given correct data" do
       before do
-        visit "/pay-foreign-marriage-certificates"
+        visit "/pay-foreign-marriage-certificates/start"
 
         within(:css, "form") do
           choose "Certificate of custom law"
@@ -66,7 +72,7 @@ feature "epdq transactions" do
     end
 
     it "displays an error and renders the form given incorrect data" do
-      visit "/pay-foreign-marriage-certificates"
+      visit "/pay-foreign-marriage-certificates/start"
 
       within(:css, "form") do
         select "3", :from => "How many documents do you require?"
@@ -116,7 +122,7 @@ feature "epdq transactions" do
 
   describe "paying to register a birth abroad" do
     it "renders the content and form" do
-      visit "/pay-register-birth-abroad"
+      visit "/pay-register-birth-abroad/start"
 
       within(:css, "header.page-header") do
         page.should have_content("Payment to register a birth abroad")
@@ -140,7 +146,7 @@ feature "epdq transactions" do
 
     context "given correct data" do
       before do
-        visit "/pay-register-birth-abroad"
+        visit "/pay-register-birth-abroad/start"
 
         within(:css, "form") do
           select "2", :from => "How many birth registrations do you need to register?"
@@ -176,7 +182,7 @@ feature "epdq transactions" do
 
   describe "paying to register a death abroad" do
     it "renders the content and form" do
-      visit "/pay-register-death-abroad"
+      visit "/pay-register-death-abroad/start"
 
       within(:css, "header.page-header") do
         page.should have_content("Payment to register a death abroad")
@@ -200,7 +206,7 @@ feature "epdq transactions" do
 
     context "given correct data" do
       before do
-        visit "/pay-register-death-abroad"
+        visit "/pay-register-death-abroad/start"
 
         within(:css, "form") do
           select "5", :from => "How many death registrations do you need to register?"
@@ -236,7 +242,7 @@ feature "epdq transactions" do
 
   describe "paying to deposit marriage and civil partnership documents" do
     it "renders the content and form" do
-      visit "/deposit-foreign-marriage"
+      visit "/deposit-foreign-marriage/start"
 
       within(:css, "header.page-header") do
         page.should have_content("Deposit foreign marriage or civil partnership certificates")
@@ -257,7 +263,7 @@ feature "epdq transactions" do
 
     context "given correct data" do
       before do
-        visit "/deposit-foreign-marriage"
+        visit "/deposit-foreign-marriage/start"
 
         within(:css, "form") do
           select "1", :from => "How many documents do you require?"
@@ -292,7 +298,7 @@ feature "epdq transactions" do
 
   describe "paying to get a document legalised by post" do
     it "renders the content and form" do
-      visit "/pay-legalisation-post"
+      visit "/pay-legalisation-post/start"
 
       within(:css, "header.page-header") do
         page.should have_content("Pay to legalise documents by post")
@@ -317,7 +323,7 @@ feature "epdq transactions" do
 
     context "given correct data" do
       before do
-        visit "/pay-legalisation-post"
+        visit "/pay-legalisation-post/start"
 
         within(:css, "form") do
           select "1", :from => "How many documents do you require?"
@@ -350,7 +356,7 @@ feature "epdq transactions" do
     end
 
     it "displays an error and renders the form given incorrect data" do
-      visit "/pay-legalisation-post"
+      visit "/pay-legalisation-post/start"
 
       within(:css, "form") do
         select "3", :from => "How many documents do you require?"
@@ -365,7 +371,7 @@ feature "epdq transactions" do
 
   describe "paying to get a document legalised using the drop-off service" do
     it "renders the content and form" do
-      visit "/pay-legalisation-drop-off"
+      visit "/pay-legalisation-drop-off/start"
 
       within(:css, "header.page-header") do
         page.should have_content("Pay to legalise documents using the drop-off service")
@@ -387,7 +393,7 @@ feature "epdq transactions" do
 
     context "given correct data" do
       before do
-        visit "/pay-legalisation-drop-off"
+        visit "/pay-legalisation-drop-off/start"
 
         within(:css, "form") do
           select "5", :from => "How many documents do you require?"
@@ -420,7 +426,7 @@ feature "epdq transactions" do
   end
 
   it "renders a 404 error on for an invalid transaction slug" do
-    visit "/pay-for-bunting"
+    visit "/pay-for-bunting/start"
 
     page.status_code.should == 404
   end


### PR DESCRIPTION
We're going to create standard transaction start pages in the Publishing Platform at `/<transaction>` and have the app handle paths at `/<transaction>/start`, `/<transaction>/confirm` and `/<transaction>/done`.
