### PR TITLE
Switch between multiple EPDQ account configurations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/'
 gem 'rails', '3.2.12'
 gem 'unicorn', '4.3.1'
 
-gem 'epdq', :git => "https://github.com/alphagov/epdq.git"
+gem 'epdq', :git => "https://github.com/alphagov/epdq.git", :branch => "account-object"
 
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: https://github.com/alphagov/epdq.git
-  revision: da785ee26672d9d2d7935aeea5e280af2af36bdb
+  revision: df7dace9d465bed93a18f36c7f95878894a7c493
+  branch: account-object
   specs:
     epdq (0.0.1)
 

--- a/app/controllers/epdq_transactions_controller.rb
+++ b/app/controllers/epdq_transactions_controller.rb
@@ -25,7 +25,7 @@ class EpdqTransactionsController < ApplicationController
   end
 
   def done
-    @epdq_response = EPDQ::Response.new(request.query_string)
+    @epdq_response = EPDQ::Response.new(request.query_string, @transaction.account)
 
     if @epdq_response.valid_shasign?
       render "done"
@@ -41,6 +41,7 @@ private
 
   def build_epdq_request(transaction, total_cost_in_gbp)
     @epdq_request = EPDQ::Request.new(
+      :account => transaction.account,
       :orderid => SecureRandom.hex(15),
       :amount => (total_cost_in_gbp * 100).round,
       :currency => "GBP",

--- a/config/initializers/epdq.rb
+++ b/config/initializers/epdq.rb
@@ -1,5 +1,23 @@
-EPDQ.pspid = ENV["epdq_pspid"] || 'pspid'
-EPDQ.sha_type = :sha1
-EPDQ.sha_in = ENV["epdq_sha_in"] || "00000000000000000000000000000000000000000"
-EPDQ.sha_out = ENV["epdq_sha_out"] || "00000000000000000000000000000000000000000"
-EPDQ.test_mode = true
+EPDQ.accounts = {
+  'legalisation-post' => EPDQ::Account.new(
+    :pspid => ENV["epdq_legalisation_pspid"] || 'pspid',
+    :sha_type => :sha1,
+    :sha_in => ENV["epdq_legalisation_post_sha_in"] || "00000000000000000000000000000000000000000",
+    :sha_out => ENV["epdq_legalisation_post_sha_out"] || "00000000000000000000000000000000000000000",
+    :test_mode => true
+  ),
+  'legalisation-drop-off' => EPDQ::Account.new(
+    :pspid => ENV["epdq_pspid"] || 'pspid',
+    :sha_type => :sha1,
+    :sha_in => ENV["epdq_legalisation_dropoff_sha_in"] || "00000000000000000000000000000000000000000",
+    :sha_out => ENV["epdq_legalisation_dropoff_sha_out"] || "00000000000000000000000000000000000000000",
+    :test_mode => true
+  ),
+  'birth-death-marriage' => EPDQ::Account.new(
+    :pspid => ENV["epdq_birth_pspid"] || 'pspid',
+    :sha_type => :sha1,
+    :sha_in => ENV["epdq_birth_sha_in"] || "00000000000000000000000000000000000000000",
+    :sha_out => ENV["epdq_birth_sha_out"] || "00000000000000000000000000000000000000000",
+    :test_mode => true
+  )
+}

--- a/lib/transactions.yml
+++ b/lib/transactions.yml
@@ -7,11 +7,13 @@ pay-foreign-marriage-certificates:
     certificate-of-no-impediment: Certificate of no impediment
     nulla-osta: Nulla osta
     certificate-of-custom-law: Certificate of custom law
+  account: birth-death-marriage
 deposit-foreign-marriage:
   title: Deposit foreign marriage or civil partnership certificates
   document_cost: 35
   postage_cost: 10
   registration: false
+  account: birth-death-marriage
 pay-register-death-abroad:
   title: Payment to register a death abroad
   document_cost: 65
@@ -19,6 +21,7 @@ pay-register-death-abroad:
   registration: true
   registration_cost: 105
   registration_type: death
+  account: birth-death-marriage
 pay-register-birth-abroad:
   title: Payment to register a birth abroad
   document_cost: 65
@@ -26,6 +29,7 @@ pay-register-birth-abroad:
   registration: true
   registration_cost: 105
   registration_type: birth
+  account: birth-death-marriage
 pay-legalisation-post:
   title: Pay to legalise documents by post
   document_cost: 30
@@ -45,7 +49,9 @@ pay-legalisation-post:
     rest-of-world:
       label: "Rest of the World"
       cost: 25
+  account: legalisation-post
 pay-legalisation-drop-off:
   title: Pay to legalise documents using the drop-off service
   document_cost: 75
   postage_cost: false
+  account: legalisation-drop-off

--- a/spec/controllers/epdq_transactions_controller_spec.rb
+++ b/spec/controllers/epdq_transactions_controller_spec.rb
@@ -58,6 +58,12 @@ describe EpdqTransactionsController do
       response.should be_not_found
     end
 
+    it "builds an epdq request with the correct account" do
+      EPDQ::Request.should_receive(:new).with(hash_including(:account => "legalisation-drop-off"))
+
+      post :confirm, :slug => "pay-legalisation-drop-off", :transaction => { :document_count => "5" }
+    end
+
     describe "with multiple document types" do
       context "given valid values" do
         before do
@@ -194,6 +200,13 @@ describe EpdqTransactionsController do
     it "returns 404 status if slug is empty" do
       post :confirm, :slug => ""
       response.should be_not_found
+    end
+
+    it "should build an EPDQ response for the correct account" do
+      response_stub = stub(:valid_shasign? => true)
+      EPDQ::Response.should_receive(:new).with(anything(), "birth-death-marriage").and_return(response_stub)
+
+      get :done, :slug => "deposit-foreign-marriage"
     end
 
     describe "for a standard transaction" do


### PR DESCRIPTION
We need to make payment to one of multiple EPDQ accounts, depending on the transaction.

This introduces behaviour to select the correct account and provide it to the alphagov fork of the EPDQ gem. There are also supporting changes to the configuration initializer.
