### PR TITLE
Set expiry headers for transaction start pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,4 +17,10 @@ class ApplicationController < ActionController::Base
       "#{Plek.current.find("www")}/"
     end
   end
+
+  def set_expiry(duration = 30.minutes)
+    unless Rails.env.development?
+      expires_in(duration, :public => true)
+    end
+  end
 end

--- a/app/controllers/epdq_transactions_controller.rb
+++ b/app/controllers/epdq_transactions_controller.rb
@@ -1,6 +1,8 @@
 class EpdqTransactionsController < ApplicationController
 
   before_filter :find_transaction, :except => :index
+  before_filter :set_expiry, :only => :start
+
   rescue_from Transaction::TransactionNotFound, :with => :error_404
 
   def index

--- a/spec/controllers/epdq_transactions_controller_spec.rb
+++ b/spec/controllers/epdq_transactions_controller_spec.rb
@@ -36,7 +36,7 @@ describe EpdqTransactionsController do
       end
 
       it "sets the correct expiry headers" do
-        assert_equal "max-age=1800, public",  response.headers["Cache-Control"]
+        response.headers["Cache-Control"].should == "max-age=1800, public"
       end
 
       it "is successful" do

--- a/spec/controllers/epdq_transactions_controller_spec.rb
+++ b/spec/controllers/epdq_transactions_controller_spec.rb
@@ -35,6 +35,10 @@ describe EpdqTransactionsController do
         get :start, :slug => "pay-foreign-marriage-certificates"
       end
 
+      it "sets the correct expiry headers" do
+        assert_equal "max-age=1800, public",  response.headers["Cache-Control"]
+      end
+
       it "is successful" do
         response.should be_success
       end


### PR DESCRIPTION
Only set these on the start page, as they are static and do not change based on the user's responses.
