### PR TITLE
Change the document_count field to a text box for legalisation

### DIFF
--- a/app/controllers/epdq_transactions_controller.rb
+++ b/app/controllers/epdq_transactions_controller.rb
@@ -24,6 +24,9 @@ class EpdqTransactionsController < ApplicationController
   rescue Transaction::InvalidPostageOption
     @errors = [:postage_option]
     render :action => "start"
+  rescue Transaction::InvalidDocumentCount
+    @errors = [:document_count]
+    render :action => "start"
   end
 
   def done
@@ -53,7 +56,7 @@ private
     )
   end
 
-  def paramplus_value 
+  def paramplus_value
     [].tap do |ary|
       Transaction::PARAMPLUS_KEYS.each do |key|
         if params[:transaction].has_key?(key)

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -4,9 +4,10 @@ class Transaction < OpenStruct
   class TransactionNotFound < StandardError; end
   class InvalidDocumentType < StandardError; end
   class InvalidPostageOption < StandardError; end
+  class InvalidDocumentCount < StandardError; end
 
   PARAMPLUS_KEYS = ['document_count', 'postage', 'postage_option', 'registration_count']
-  
+
   def calculate_total(values)
     calculator = TransactionCalculator.new(self)
     calculator.calculate(values)

--- a/app/views/partials/questions/_document_count.html.erb
+++ b/app/views/partials/questions/_document_count.html.erb
@@ -1,1 +1,5 @@
-<%= render "partials/questions/number_dropdown", :question_text => question_text, :transaction_key => "document_count" %>
+<% if local_assigns[:question_type] and question_type == :text %>
+  <%= render "partials/questions/number_field", :question_text => question_text, :transaction_key => "document_count" %>
+<% else %>
+  <%= render "partials/questions/number_dropdown", :question_text => question_text, :transaction_key => "document_count" %>
+<% end %>

--- a/app/views/partials/questions/_number_field.html.erb
+++ b/app/views/partials/questions/_number_field.html.erb
@@ -1,0 +1,6 @@
+<p>
+  <%= label_tag "transaction_#{transaction_key}" do %>
+    <%= raw(question_text) %><br />
+    <%= text_field_tag "transaction[#{transaction_key}]", nil, :id => "transaction_#{transaction_key}", :size => 10 %>
+  <% end %>
+</p>

--- a/app/views/partials/transactions/pay-legalisation-drop-off/_intro.html.erb
+++ b/app/views/partials/transactions/pay-legalisation-drop-off/_intro.html.erb
@@ -1,1 +1,1 @@
-<%= render "partials/questions/document_count", :question_text => "How many documents do you want legalised?<br>Each document costs &pound;75." %>
+<%= render "partials/questions/document_count", :question_text => "How many documents do you want legalised?<br>Each document costs &pound;75.", :question_type => :text %>

--- a/app/views/partials/transactions/pay-legalisation-post/_intro.html.erb
+++ b/app/views/partials/transactions/pay-legalisation-post/_intro.html.erb
@@ -1,4 +1,4 @@
-<%= render "partials/questions/document_count", :question_text => "How many documents do you want legalised?<br>Each document costs &pound;#{@transaction.document_cost}." %>
+<%= render "partials/questions/document_count", :question_text => "How many documents do you want legalised?<br>Each document costs &pound;#{@transaction.document_cost}.", :question_type => :text %>
 
 <%= render "partials/questions/postage_options", :question_text => "How would you like your documents sent back to you?" %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,3 +6,4 @@ en:
     errors:
       document_type: Please choose a document type
       postage_option: Please choose a postage option
+      document_count: Document count must be a number

--- a/lib/transaction_calculator.rb
+++ b/lib/transaction_calculator.rb
@@ -7,6 +7,10 @@ class TransactionCalculator
 
   def calculate(values)
     document_count = values[:document_count].to_i
+    if document_count
+      raise Transaction::InvalidDocumentCount unless values[:document_count].to_s =~ %r{\A[0-9]*\z}
+    end
+
     postage = values[:postage] == "yes"
     document_type = values[:document_type]
     postage_option = values[:postage_option]

--- a/spec/controllers/epdq_transactions_controller_spec.rb
+++ b/spec/controllers/epdq_transactions_controller_spec.rb
@@ -68,6 +68,24 @@ describe EpdqTransactionsController do
       post :confirm, :slug => "pay-legalisation-drop-off", :transaction => { :document_count => "5" }
     end
 
+    context "given an invalid document count" do
+      before do
+        post :confirm, :slug => "pay-legalisation-drop-off", :transaction => {
+          :document_count => "test",
+          :postage => "yes",
+        }
+      end
+
+      it "renders the start template" do
+        @controller.should render_template("start")
+        response.should be_success
+      end
+
+      it "assigns an error message" do
+        assigns(:errors).should =~ [:document_count]
+      end
+    end
+
     describe "with multiple document types" do
       context "given valid values" do
         before do

--- a/spec/features/epdq_transactions_spec.rb
+++ b/spec/features/epdq_transactions_spec.rb
@@ -322,7 +322,7 @@ feature "epdq transactions" do
         page.should have_content("How many documents do you want legalised?")
 
         page.should have_content("Each document costs £30.")
-        page.should have_select("transaction_document_count", :options => ["1","2","3","4","5","6","7","8","9"])
+        page.should have_field("transaction_document_count")
 
         page.should have_content("How would you like your documents sent back to you?")
         page.should have_unchecked_field("Prepaid envelope that you provide (UK only) - £0")
@@ -340,7 +340,7 @@ feature "epdq transactions" do
         visit "/pay-legalisation-post/start"
 
         within(:css, "form") do
-          select "1", :from => "transaction_document_count"
+          fill_in "transaction_document_count", :with => "1"
           choose "Tracked courier service to the rest of the world - £25"
         end
 
@@ -373,13 +373,23 @@ feature "epdq transactions" do
       visit "/pay-legalisation-post/start"
 
       within(:css, "form") do
-        select "3", :from => "transaction_document_count"
+        fill_in "transaction_document_count", :with => "3"
       end
 
       click_on "Calculate total"
 
       page.should have_selector("p.error-message", :text => "Please choose a postage option")
       page.should have_content("How would you like your documents sent back to you?")
+    end
+
+    it "returns an error if document count is not an integer" do
+      visit "/pay-legalisation-drop-off/start"
+
+      fill_in "transaction_document_count", :with => "definitely not a number"
+      click_on "Calculate total"
+
+      page.should have_selector("p.error-message", :text => "Document count must be a number")
+      page.should_not have_button "Pay"
     end
   end
 
@@ -395,7 +405,7 @@ feature "epdq transactions" do
         page.should have_content("How many documents do you want legalised?")
 
         page.should have_content("Each document costs £75.")
-        page.should have_select("transaction_document_count", :options => ["1","2","3","4","5","6","7","8","9"])
+        page.should have_field("transaction_document_count")
 
         page.should have_no_content("Which postage method do you require?")
         page.should have_no_content("Do you require postage?")
@@ -410,7 +420,7 @@ feature "epdq transactions" do
         visit "/pay-legalisation-drop-off/start"
 
         within(:css, "form") do
-          select "5", :from => "transaction_document_count"
+          fill_in "transaction_document_count", :with => "5"
         end
 
         click_on "Calculate total"
@@ -436,6 +446,16 @@ feature "epdq transactions" do
           page.should have_button("Pay")
         end
       end
+    end
+
+    it "returns an error if document count is not an integer" do
+      visit "/pay-legalisation-drop-off/start"
+
+      fill_in "transaction_document_count", :with => "definitely not a number"
+      click_on "Calculate total"
+
+      page.should have_selector("p.error-message", :text => "Document count must be a number")
+      page.should_not have_button "Pay"
     end
   end
 

--- a/spec/lib/transaction_calculator_spec.rb
+++ b/spec/lib/transaction_calculator_spec.rb
@@ -34,6 +34,10 @@ describe TransactionCalculator do
     it "builds an item list with postage" do
       @calculator.calculate(:document_count => 5, :postage => "yes").item_list.should == "5 documents plus postage"
     end
+
+    it "raises an error if the document count is not an integer" do
+      expect{ @calculator.calculate(:document_count => "lots") }.to raise_error(Transaction::InvalidDocumentCount)
+    end
   end
 
   describe "given a transaction with multiple document types" do


### PR DESCRIPTION
For legalisation transactions, change the document count field to
a text box, rather than a select field, so that users can enter a
quantity larger than 9.
