### PR TITLE
Inject journey description into markup

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,1 +1,2 @@
-//= require_tree .
+//= require stageprompt.js
+//= require init_stageprompt.js

--- a/app/assets/javascripts/init_stageprompt.js
+++ b/app/assets/javascripts/init_stageprompt.js
@@ -1,0 +1,5 @@
+$(function () {
+  GOVUK.performance.stageprompt.setup(function (journeyStage) {
+    _gaq.push(['_trackEvent', journeyStage , 'n/a', undefined, undefined, true]);
+  })
+});

--- a/app/assets/javascripts/stageprompt.js
+++ b/app/assets/javascripts/stageprompt.js
@@ -1,0 +1,21 @@
+/*jslint indent: 2 */
+/*global $ */
+
+var GOVUK = GOVUK || {};
+
+GOVUK.performance = GOVUK.performance || {};
+
+GOVUK.performance.stageprompt = (function () {
+  var setup;
+
+  setup = function (analyticsCallback) {
+    var journeyStage = $('[data-journey]').attr('data-journey');
+    if (journeyStage) {
+      analyticsCallback(journeyStage);
+    }
+  };
+
+  return {
+    setup: setup
+  };
+}());

--- a/app/helpers/epdq_transactions_helper.rb
+++ b/app/helpers/epdq_transactions_helper.rb
@@ -15,6 +15,10 @@ module EpdqTransactionsHelper
     end.join(" and ")
   end
 
+  def data_journey
+    "data-journey=#{@journey_description}" if @journey_description.present?
+  end
+
   private
 
   def document_count

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,5 +11,6 @@
 
       <%= yield %>
     </div>
+  <%= javascript_include_tag "application" %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,8 @@
   </head>
 
   <body class="mainstream <%= yield :body_classes %>">
-    <div id="wrapper" class="<%= yield :wrapper_classes %>">
+    <div id="wrapper" class="<%= yield :wrapper_classes %>" <%= data_journey %>>
+
       <%= yield %>
     </div>
   </body>

--- a/spec/controllers/epdq_transactions_controller_spec.rb
+++ b/spec/controllers/epdq_transactions_controller_spec.rb
@@ -53,6 +53,10 @@ describe EpdqTransactionsController do
         assigns(:transaction).document_cost.should == 65
         assigns(:transaction).registration.should be_false
       end
+
+      it "assigns the journey description" do
+        assigns(:journey_description).should == "pay-foreign-marriage-certificates:start"
+      end
     end
   end
 
@@ -137,6 +141,10 @@ describe EpdqTransactionsController do
           assigns(:epdq_request).parameters[:amount].should == 33500
           assigns(:epdq_request).parameters[:accepturl].should == "http://www.dev.gov.uk/pay-foreign-marriage-certificates/done"
         end
+
+        it "assigns the journey description" do
+          assigns(:journey_description).should == "pay-foreign-marriage-certificates:confirm"
+        end
       end
 
       context "given no document type" do
@@ -153,6 +161,10 @@ describe EpdqTransactionsController do
 
         it "assigns an error message" do
           assigns(:errors).should =~ [:document_type]
+        end
+
+        it "assigns the journey description" do
+          assigns(:journey_description).should == "pay-foreign-marriage-certificates:invalid_form"
         end
       end
 
@@ -171,6 +183,10 @@ describe EpdqTransactionsController do
 
         it "assigns an error message" do
           assigns(:errors).should =~ [:document_type]
+        end
+
+        it "assigns the journey description" do
+          assigns(:journey_description).should == "pay-foreign-marriage-certificates:invalid_form"
         end
       end
     end
@@ -208,6 +224,10 @@ describe EpdqTransactionsController do
           assigns(:epdq_request).parameters[:amount].should == 86000
           assigns(:epdq_request).parameters[:accepturl].should == "http://www.dev.gov.uk/pay-register-birth-abroad/done"
         end
+
+        it "assigns the journey description" do
+          assigns(:journey_description).should == "pay-register-birth-abroad:confirm"
+        end
       end
     end
 
@@ -231,6 +251,10 @@ describe EpdqTransactionsController do
 
         it "renders the confirm template" do
           @controller.should render_template("confirm")
+        end
+
+        it "assigns the journey description" do
+          assigns(:journey_description).should == "deposit-foreign-marriage:confirm"
         end
       end
     end
@@ -291,6 +315,10 @@ describe EpdqTransactionsController do
           assigns(:epdq_response).parameters[:document_count].should == "3"
           assigns(:epdq_response).parameters[:postage].should == "yes"
         end
+
+        it "assigns the journey description" do
+          assigns(:journey_description).should == "deposit-foreign-marriage:done"
+        end
       end
 
       context "given invalid parameters" do
@@ -318,9 +346,12 @@ describe EpdqTransactionsController do
         it "should render the error template" do
           @controller.should render_template("error")
         end
+
+        it "assigns the journey description" do
+          assigns(:journey_description).should == "deposit-foreign-marriage:payment_error"
+        end
       end
 
     end
   end
-
 end

--- a/spec/features/epdq_transactions_spec.rb
+++ b/spec/features/epdq_transactions_spec.rb
@@ -34,6 +34,9 @@ feature "epdq transactions" do
 
         page.should have_button("Calculate total")
       end
+
+      find("#wrapper")["data-journey"].should == "pay-foreign-marriage-certificates:start"
+
     end
 
     context "given correct data" do


### PR DESCRIPTION
Add a data attribute to markup with information about the current step
inside user journey; this information is used by performance platform's
Stageprompt to collect analytics data about the user journey.

(Stageprompt is the name for the wire up code and format we use for
describing user journeys.)
