### PR TITLE
Bump slimmer to 3.16.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'epdq', :git => "https://github.com/alphagov/epdq.git", :branch => "gds_mast
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'
 else
-  gem 'slimmer', '3.12.0'
+  gem 'slimmer', '3.16.0'
 end
 
 gem 'plek', '1.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
     simplecov-html (0.7.1)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (3.12.0)
+    slimmer (3.16.0)
       json
       lrucache (~> 0.1.3)
       nokogiri (~> 1.5.0)
@@ -181,7 +181,7 @@ DEPENDENCIES
   rails (= 3.2.13)
   rspec-rails (= 2.12.0)
   simplecov-rcov (= 0.2.3)
-  slimmer (= 3.12.0)
+  slimmer (= 3.16.0)
   uglifier (>= 1.0.3)
   unicorn (= 4.3.1)
   webmock (= 1.9.0)


### PR DESCRIPTION
To enable us to fix the breadcrumb markup
