### PR TITLE
Adding copy to birth and death transaction wrappers

### DIFF
--- a/app/views/partials/transactions/pay-register-birth-abroad/_intro.html.erb
+++ b/app/views/partials/transactions/pay-register-birth-abroad/_intro.html.erb
@@ -1,5 +1,9 @@
+<p>Pay the Foreign &amp; Commonwealth Office (FCO) to register the death of a British national abroad. You must be back in the UK to use this service.</p>
 <%= render "partials/questions/registration_count", :question_text => "How many registrations do you need to pay for? Each one costs &pound;#{@transaction.registration_cost}." %>
 
 <%= render "partials/questions/document_count", :question_text => "How many birth certificates do you need? Each one costs &pound;#{@transaction.document_cost}." %>
 
 <%= render "partials/questions/postage_fee_yes_no", :question_text => "Do you require postage? This costs &pound;#{@transaction.postage_cost}." %>
+<div class="application-notice help-notice">
+<p>You must be back in the UK to use this service.</p>
+</div>

--- a/app/views/partials/transactions/pay-register-death-abroad/_intro.html.erb
+++ b/app/views/partials/transactions/pay-register-death-abroad/_intro.html.erb
@@ -1,6 +1,9 @@
-<p>Pay the Foreign &amp; Commonwealth Office (FCO) to register the death of a British national abroad.</p>
+<p>Pay the Foreign &amp; Commonwealth Office (FCO) to register the death of a British national abroad. You must be back in the UK to use this service.</p>
 <%= render "partials/questions/registration_count", :question_text => "How many registrations do you need to pay for? Each one costs &pound;#{@transaction.registration_cost}." %>
 
 <%= render "partials/questions/document_count", :question_text => "How many death certificates do you need? Each one costs &pound;#{@transaction.document_cost}." %>
 
 <%= render "partials/questions/postage_fee_yes_no", :question_text => "Do you want to pay the &pound;#{@transaction.postage_cost} postage fee to have your documents returned?" %>
+<div class="application-notice help-notice">
+<p>You must be back in the UK to use this service.</p>
+</div>

--- a/spec/features/pay_register_birth_abroad_spec.rb
+++ b/spec/features/pay_register_birth_abroad_spec.rb
@@ -10,6 +10,7 @@ describe "paying to register a birth abroad" do
     end
 
     within(:css, "form") do
+      page.should have_content("Pay the Foreign & Commonwealth Office (FCO) to register the death of a British national abroad. You must be back in the UK to use this service.")
       page.should have_content("How many registrations do you need to pay for? Each one costs £105.")
       page.should have_select("transaction_registration_count", :options => ["1","2","3","4","5","6","7","8","9"])
 
@@ -20,6 +21,8 @@ describe "paying to register a birth abroad" do
       page.should have_content("Do you require postage? This costs £10.")
       page.should have_select("transaction_postage", :options => ["Yes", "No"])
 
+      page.should have_content("You must be back in the UK to use this service.")
+      
       page.should have_button("Calculate total")
     end
   end

--- a/spec/features/pay_register_death_abroad_spec.rb
+++ b/spec/features/pay_register_death_abroad_spec.rb
@@ -10,7 +10,7 @@ describe "paying to register a death abroad" do
     end
 
     within(:css, "form") do
-      page.should have_content("Pay the Foreign & Commonwealth Office (FCO) to register the death of a British national abroad.")
+      page.should have_content("Pay the Foreign & Commonwealth Office (FCO) to register the death of a British national abroad. You must be back in the UK to use this service.")
       page.should have_content("Each one costs £105.")
       page.should have_select("transaction_registration_count", :options => ["1","2","3","4","5","6","7","8","9"])
 
@@ -20,6 +20,8 @@ describe "paying to register a death abroad" do
 
       page.should have_content("Do you want to pay the £10 postage fee to have your documents returned?")
       page.should have_select("transaction_postage", :options => ["Yes", "No"])
+
+      page.should have_content("You must be back in the UK to use this service.")
 
       page.should have_button("Calculate total")
     end


### PR DESCRIPTION
Adding sentence(s) and 'warning' call-out boxes to payment to register a birth and payment to register a death.
