### PR TITLE
Deposit foreign marriage certificate - Fix typo, change 'aboard' to 'abroad'

### DIFF
--- a/app/views/partials/transactions/deposit-foreign-marriage/_intro.html.erb
+++ b/app/views/partials/transactions/deposit-foreign-marriage/_intro.html.erb
@@ -1,4 +1,4 @@
-<p>Deposit your marriage or civil partnership certificate at the General Register Office (GRO) for safe-keeping if you got married aboard and you’re resident in the UK.</p>
+<p>Deposit your marriage or civil partnership certificate at the General Register Office (GRO) for safe-keeping if you got married abroad and you’re resident in the UK.</p>
 
 <%= render "partials/questions/document_count", :question_text => "How many certificates do you need to deposit? Each one costs &pound;#{@transaction.document_cost}." %>
 

--- a/spec/features/deposit_foreign_marriage_spec.rb
+++ b/spec/features/deposit_foreign_marriage_spec.rb
@@ -10,7 +10,7 @@ describe "paying to deposit marriage and civil partnership documents" do
     end
 
     within(:css, "form") do
-      page.should have_content("Deposit your marriage or civil partnership certificate at the General Register Office (GRO) for safe-keeping if you got married aboard and you’re resident in the UK.")
+      page.should have_content("Deposit your marriage or civil partnership certificate at the General Register Office (GRO) for safe-keeping if you got married abroad and you’re resident in the UK.")
 
       page.should have_content("Each one costs £35.")
       page.should have_select("transaction_document_count", :options => ["1","2","3","4","5","6","7","8","9"])


### PR DESCRIPTION
Part of [this story](https://www.pivotaltracker.com/story/show/57465524)
(No dependencies)
