### PR TITLE
Removing an option from 'pay to legalise documents by post' as it's no longer offered

### DIFF
--- a/lib/transactions.yml
+++ b/lib/transactions.yml
@@ -41,9 +41,6 @@ pay-legalisation-post:
     uk:
       label: Tracked courier service to the UK or British Forces Post Office
       cost: 6
-    uk-with-insurance:
-      label: Tracked courier service to the UK or British Forces Post Office, with insurance
-      cost: 12
     europe:
       label: Tracked courier service to Europe (excluding Russia, Turkey, Bosnia, Croatia, Albania, Belarus, Macedonia, Moldova, Montenegro, Ukraine)
       cost: 14.50

--- a/spec/features/pay_legalisation_post_spec.rb
+++ b/spec/features/pay_legalisation_post_spec.rb
@@ -18,7 +18,6 @@ describe "paying to get a document legalised by post" do
       page.should have_content("How would you like your documents sent back to you?")
       page.should have_unchecked_field("Prepaid envelope that you provide (UK only) - £0")
       page.should have_unchecked_field("Tracked courier service to the UK or British Forces Post Office - £6")
-      page.should have_unchecked_field("Tracked courier service to the UK or British Forces Post Office, with insurance - £12")
       page.should have_unchecked_field("Tracked courier service to Europe (excluding Russia, Turkey, Bosnia, Croatia, Albania, Belarus, Macedonia, Moldova, Montenegro, Ukraine) - £14.50")
       page.should have_unchecked_field("Tracked courier service to the rest of the world - £25")
 
@@ -67,12 +66,12 @@ describe "paying to get a document legalised by post" do
 
     within(:css, "form") do
       fill_in "transaction_document_count", :with => "0"
-      choose "Tracked courier service to the UK or British Forces Post Office, with insurance - £12"
+      choose "Tracked courier service to the UK or British Forces Post Office - £6"
     end
 
     click_on "Calculate total"
 
-    page.should have_content("It costs £12 for 0 documents plus Tracked courier service to the UK or British Forces Post Office, with insurance")
+    page.should have_content("It costs £6 for 0 documents plus Tracked courier service to the UK or British Forces Post Office")
   end
 
   it "displays an error and renders the form given incorrect data" do


### PR DESCRIPTION
The 'tracked courier service to UK & BFPO with insurance' is no longer available so needs to be removed.
