### PR TITLE
Removing 'not what you're looking for' link

### DIFF
--- a/app/views/epdq_transactions/confirm.html.erb
+++ b/app/views/epdq_transactions/confirm.html.erb
@@ -4,7 +4,6 @@
     <div>
       <h1><span>Service</span> <%= @transaction.title %></h1>
     </div>
-    <a class="skip-to-related" href="#related">Not what you're looking for? ↓</a>
   </header>
   <div class="article-container group">
       <article role="article" class="group">

--- a/app/views/epdq_transactions/done.html.erb
+++ b/app/views/epdq_transactions/done.html.erb
@@ -4,7 +4,6 @@
     <div>
       <h1><span>Service</span> <%= @transaction.title %></h1>
     </div>
-    <a class="skip-to-related" href="#related">Not what you're looking for? ↓</a>
   </header>
   <div class="article-container group">
       <article role="article" class="group">

--- a/app/views/epdq_transactions/payment_error.html.erb
+++ b/app/views/epdq_transactions/payment_error.html.erb
@@ -4,7 +4,6 @@
     <div>
       <h1><span>Service</span> <%= @transaction.title %></h1>
     </div>
-    <a class="skip-to-related" href="#related">Not what you're looking for? ↓</a>
   </header>
   <div class="article-container group">
       <article role="article" class="group">

--- a/app/views/epdq_transactions/start.html.erb
+++ b/app/views/epdq_transactions/start.html.erb
@@ -4,7 +4,6 @@
     <div>
       <h1><span>Service</span> <%= @transaction.title %></h1>
     </div>
-    <a class="skip-to-related" href="#related">Not what you're looking for? ↓</a>
   </header>
   <div class="article-container group">
       <article role="article" class="group">


### PR DESCRIPTION
Usage is negligible (0.352% of pageviews result in it being clicked)
and it's a jarring experience

Related pull requests on other branches — 

alphagov/frontend/pull/512
alphagov/smart-answers/pull/700
alphagov/licence-finder/pull/51
alphagov/calendars/pull/57
alphagov/prototyping-v2/pull/1
alphagov/transaction-wrappers/pull/42
