### PR TITLE
Correct zero padding bug

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,7 +4,7 @@ module ApplicationHelper
     case value.to_s
     when %r{\A[0-9]+\z} then value
     else
-      "%0.2f" % value
+      number_to_currency(value, :precision => 2, :unit => nil)
     end
   end
 end

--- a/spec/features/pay_legalisation_post_spec.rb
+++ b/spec/features/pay_legalisation_post_spec.rb
@@ -74,6 +74,20 @@ describe "paying to get a document legalised by post" do
     page.should have_content("It costs £4.50 for 0 documents plus Tracked courier service to the UK or British Forces Post Office including Isle of Man and Channel Islands")
   end
 
+  it "should format calculated costs correctly" do
+
+    visit "/pay-legalisation-post/start"
+
+    within(:css, "form") do
+      fill_in "transaction_document_count", :with => "1"
+      choose "Tracked courier service to the UK or British Forces Post Office including Isle of Man and Channel Islands - £4.50"
+    end
+
+    click_on "Calculate total"
+
+    page.should have_content("It costs £34.50 for 1 document plus Tracked courier service to the UK or British Forces Post Office including Isle of Man and Channel Islands")
+  end
+
   it "displays an error and renders the form given incorrect data" do
     visit "/pay-legalisation-post/start"
 


### PR DESCRIPTION
Transaction calculations were not zero padding partial pound monetary values correctly. eg. `16.5` would appear rather than `16.50`.
